### PR TITLE
Add PHP dotenv example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DB_HOST=localhost
+DB_USER=user
+DB_PASS=secret

--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ php public/index.php
 ```
 
 You should see the values from your `.env` file printed to the console.
+
+## Running tests
+
+Execute the PHPUnit suite to verify the configuration loader:
+
+```bash
+vendor/bin/phpunit
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # codex
-test codex 
+
+This repository demonstrates how to load environment variables using **phpdotenv** in a basic PHP setup.
+
+## Setup
+
+1. Install dependencies (requires Composer):
+
+```bash
+composer install
+```
+
+2. Copy `.env.example` to `.env` and adjust values as needed:
+
+```bash
+cp .env.example .env
+```
+
+3. Run the example script:
+
+```bash
+php public/index.php
+```
+
+You should see the values from your `.env` file printed to the console.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,10 @@
+{
+    "require": {
+        "vlucas/phpdotenv": "^5.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -6,5 +6,13 @@
         "psr-4": {
             "App\\": "src/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "App\\Tests\\": "tests/"
+        }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use App\Infrastructure\Config\EnvConfig;
+
+$config = new EnvConfig(__DIR__ . '/..');
+
+$dbHost = $config->get('DB_HOST', 'localhost');
+$dbUser = $config->get('DB_USER', 'root');
+$dbPass = $config->get('DB_PASS', 'secret');
+
+echo "Host: $dbHost\n";
+echo "User: $dbUser\n";
+echo "Pass: $dbPass\n";

--- a/src/Infrastructure/Config/EnvConfig.php
+++ b/src/Infrastructure/Config/EnvConfig.php
@@ -1,0 +1,18 @@
+<?php
+namespace App\Infrastructure\Config;
+
+use Dotenv\Dotenv;
+
+class EnvConfig
+{
+    public function __construct(string $projectRoot)
+    {
+        $dotenv = Dotenv::createImmutable($projectRoot);
+        $dotenv->load();
+    }
+
+    public function get(string $key, ?string $default = null): ?string
+    {
+        return $_ENV[$key] ?? $default;
+    }
+}

--- a/tests/EnvConfigTest.php
+++ b/tests/EnvConfigTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace App\Tests;
+
+use PHPUnit\Framework\TestCase;
+use App\Infrastructure\Config\EnvConfig;
+
+class EnvConfigTest extends TestCase
+{
+    private string $envFile;
+
+    protected function setUp(): void
+    {
+        $this->envFile = __DIR__ . '/.env';
+        copy(__DIR__ . '/../.env.example', $this->envFile);
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->envFile)) {
+            unlink($this->envFile);
+        }
+        unset($_ENV['DB_HOST'], $_ENV['DB_USER'], $_ENV['DB_PASS']);
+    }
+
+    public function testLoadsEnvVariables(): void
+    {
+        $config = new EnvConfig(__DIR__);
+        $this->assertSame('localhost', $config->get('DB_HOST'));
+        $this->assertSame('user', $config->get('DB_USER'));
+        $this->assertSame('secret', $config->get('DB_PASS'));
+    }
+}


### PR DESCRIPTION
## Summary
- demonstrate how to load environment variables using `vlucas/phpdotenv`
- add `EnvConfig` class and example index script
- document usage in README
- provide `composer.json` and `.env.example`

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686294d3307083259491e3b5fa556c93