### PR TITLE
Add Vue parent/child communication examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,29 @@ Execute the PHPUnit suite to verify the configuration loader:
 ```bash
 vendor/bin/phpunit
 ```
+
+## Vue parent/child examples
+
+The repository also includes two minimal Vue examples that demonstrate parent-to-child data flow with props and child-to-parent updates with emitted events.
+
+### Legacy CDN version
+
+Open the standalone file in a browser:
+
+```bash
+xdg-open examples/vue-legacy/index.html
+```
+
+This version keeps everything in one HTML file and registers the child component from a regular script tag.
+
+### Structured `.vue` version
+
+Run the Vite example with single-file components:
+
+```bash
+cd examples/vue-structured
+npm install
+npm run dev
+```
+
+The parent component lives in `src/App.vue`, while the child component lives in `src/components/ChildMessage.vue`.

--- a/examples/vue-legacy/index.html
+++ b/examples/vue-legacy/index.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vue Legacy - Comunicación padre/hijo</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        font-family: Arial, sans-serif;
+        background: #f4f7fb;
+        color: #1f2937;
+      }
+
+      main {
+        width: min(680px, calc(100% - 32px));
+        padding: 32px;
+        border-radius: 18px;
+        background: #ffffff;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+      }
+
+      .card {
+        margin-top: 24px;
+        padding: 20px;
+        border: 1px solid #dbeafe;
+        border-radius: 14px;
+        background: #eff6ff;
+      }
+
+      input,
+      button {
+        padding: 10px 12px;
+        border-radius: 10px;
+        border: 1px solid #93c5fd;
+        font: inherit;
+      }
+
+      button {
+        cursor: pointer;
+        border-color: #2563eb;
+        background: #2563eb;
+        color: #ffffff;
+      }
+    </style>
+  </head>
+  <body>
+    <main id="app">
+      <h1>Versión legacy</h1>
+      <p>
+        Este ejemplo usa Vue desde CDN y componentes registrados en JavaScript.
+        El padre pasa <strong>mensaje</strong> al hijo mediante props y el hijo
+        emite <strong>actualizar-mensaje</strong> para cambiar el estado del padre.
+      </p>
+
+      <p><strong>Estado del padre:</strong> {{ mensajeDelPadre }}</p>
+
+      <child-message
+        :mensaje="mensajeDelPadre"
+        @actualizar-mensaje="actualizarMensaje"
+      ></child-message>
+    </main>
+
+    <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+    <script>
+      const { createApp } = Vue;
+
+      const ChildMessage = {
+        props: {
+          mensaje: {
+            type: String,
+            required: true,
+          },
+        },
+        emits: ['actualizar-mensaje'],
+        data() {
+          return {
+            textoLocal: '',
+          };
+        },
+        template: `
+          <section class="card">
+            <h2>Componente hijo</h2>
+            <p>Dato recibido desde el padre: <strong>{{ mensaje }}</strong></p>
+            <form @submit.prevent="enviarAlPadre">
+              <input
+                v-model="textoLocal"
+                type="text"
+                placeholder="Nuevo mensaje para el padre"
+              />
+              <button type="submit">Enviar al padre</button>
+            </form>
+          </section>
+        `,
+        methods: {
+          enviarAlPadre() {
+            const nuevoMensaje = this.textoLocal.trim();
+
+            if (!nuevoMensaje) {
+              return;
+            }
+
+            this.$emit('actualizar-mensaje', nuevoMensaje);
+            this.textoLocal = '';
+          },
+        },
+      };
+
+      createApp({
+        components: {
+          ChildMessage,
+        },
+        data() {
+          return {
+            mensajeDelPadre: 'Hola desde el padre legacy',
+          };
+        },
+        methods: {
+          actualizarMensaje(nuevoMensaje) {
+            this.mensajeDelPadre = nuevoMensaje;
+          },
+        },
+      }).mount('#app');
+    </script>
+  </body>
+</html>

--- a/examples/vue-structured/index.html
+++ b/examples/vue-structured/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vue estructurado - Comunicación padre/hijo</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/examples/vue-structured/package.json
+++ b/examples/vue-structured/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "vue-structured-parent-child",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0"
+  },
+  "dependencies": {
+    "@vitejs/plugin-vue": "^5.2.4",
+    "vite": "^5.4.19",
+    "vue": "^3.5.16"
+  },
+  "devDependencies": {}
+}

--- a/examples/vue-structured/src/App.vue
+++ b/examples/vue-structured/src/App.vue
@@ -1,0 +1,30 @@
+<script setup>
+import { ref } from 'vue';
+import ChildMessage from './components/ChildMessage.vue';
+
+const parentMessage = ref('Hola desde el padre estructurado');
+
+function updateParentMessage(newMessage) {
+  parentMessage.value = newMessage;
+}
+</script>
+
+<template>
+  <main class="app-shell">
+    <h1>Versión estructurada con .vue</h1>
+    <p>
+      El componente padre guarda el estado, lo envía al hijo con props y escucha
+      el evento <strong>update-message</strong> para actualizarlo.
+    </p>
+
+    <p class="state">
+      <span>Estado del padre:</span>
+      <strong>{{ parentMessage }}</strong>
+    </p>
+
+    <ChildMessage
+      :message="parentMessage"
+      @update-message="updateParentMessage"
+    />
+  </main>
+</template>

--- a/examples/vue-structured/src/components/ChildMessage.vue
+++ b/examples/vue-structured/src/components/ChildMessage.vue
@@ -1,0 +1,47 @@
+<script setup>
+import { ref } from 'vue';
+
+const props = defineProps({
+  message: {
+    type: String,
+    required: true,
+  },
+});
+
+const emit = defineEmits({
+  'update-message': (value) => typeof value === 'string' && value.trim().length > 0,
+});
+
+const localMessage = ref('');
+
+function sendMessageToParent() {
+  const nextMessage = localMessage.value.trim();
+
+  if (!nextMessage) {
+    return;
+  }
+
+  emit('update-message', nextMessage);
+  localMessage.value = '';
+}
+</script>
+
+<template>
+  <section class="child-card">
+    <h2>Componente hijo</h2>
+    <p>
+      Dato recibido desde el padre:
+      <strong>{{ props.message }}</strong>
+    </p>
+
+    <form @submit.prevent="sendMessageToParent">
+      <input
+        v-model="localMessage"
+        type="text"
+        placeholder="Nuevo mensaje para el padre"
+        aria-label="Nuevo mensaje para el padre"
+      />
+      <button type="submit">Enviar al padre</button>
+    </form>
+  </section>
+</template>

--- a/examples/vue-structured/src/main.js
+++ b/examples/vue-structured/src/main.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import './style.css';
+
+createApp(App).mount('#app');

--- a/examples/vue-structured/src/style.css
+++ b/examples/vue-structured/src/style.css
@@ -1,0 +1,61 @@
+:root {
+  color: #1f2937;
+  background: #f4f7fb;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+}
+
+.app-shell {
+  width: min(720px, calc(100% - 32px));
+  padding: 32px;
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+}
+
+.state,
+.child-card {
+  margin-top: 24px;
+}
+
+.state span {
+  margin-right: 8px;
+}
+
+.child-card {
+  padding: 20px;
+  border: 1px solid #dbeafe;
+  border-radius: 14px;
+  background: #eff6ff;
+}
+
+form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+input,
+button {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #93c5fd;
+  font: inherit;
+}
+
+input {
+  flex: 1 1 260px;
+}
+
+button {
+  cursor: pointer;
+  border-color: #2563eb;
+  background: #2563eb;
+  color: #ffffff;
+}

--- a/examples/vue-structured/vite.config.js
+++ b/examples/vue-structured/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+});


### PR DESCRIPTION
### Motivation

- Provide minimal, educational examples showing parent-to-child and child-to-parent communication in Vue.
- Offer both a quick legacy CDN example and a more realistic single-file component (SFC) setup with Vite to suit different learning paths.
- Demonstrate the common pattern of passing state via `props` and updating parent state via emitted events.

### Description

- Add a legacy standalone example at `examples/vue-legacy/index.html` that uses Vue from CDN, registers a child component in script, passes a `mensaje` prop and emits `actualizar-mensaje` to update the parent.
- Add a structured Vite example under `examples/vue-structured` with `package.json`, `vite.config.js`, `src/main.js`, `src/App.vue`, `src/components/ChildMessage.vue`, and `src/style.css` implementing the parent (SFC) and child (SFC) using `defineProps`/`defineEmits`.
- Update `README.md` with instructions to open the legacy file and to run the structured example with `npm install` and `npm run dev`.
- Implement simple input validation and local state clearing in the child components before emitting updates to the parent.

### Testing

- Ran `php -l public/index.php` which reported no syntax errors.
- Ran `php -l src/Infrastructure/Config/EnvConfig.php` which reported no syntax errors.
- Ran `npm install` in `examples/vue-structured` which failed with a `403 Forbidden` when fetching `@vitejs/plugin-vue` from the registry.
- Attempted `vendor/bin/phpunit` but it could not be executed because PHP dependencies are not installed (`vendor` directory missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f294eb6148325977083952873035b)